### PR TITLE
Add --branch to antigen bundle command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Prisma plugin provides some [completions](#completions) for [Prisma CLI](htt
 
 #### [antigen](https://github.com/zsh-users/antigen)
 
-Add `antigen bundle AhmedElywa/zsh-prisma` to your `~/.zshrc`.
+Add `antigen bundle AhmedElywa/zsh-prisma --branch=main` to your `~/.zshrc`.
 
 #### [oh-my-zsh](http://github.com/robbyrussell/oh-my-zsh)
 


### PR DESCRIPTION
antigen looks for the master repository if you do not set branch to main in the budle command.